### PR TITLE
Problem arguments

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -8,6 +8,7 @@ from flask import g
 from mentii import user_ctrl
 from mentii import class_ctrl
 from utils import MentiiAuth
+from problems import mathstepsWrapper
 import utils.ResponseCreation as ResponseCreation
 from utils.ResponseCreation import ControllerResponse
 import utils.MentiiLogging as MentiiLogging
@@ -245,6 +246,19 @@ def changeUserRole():
     res = user_ctrl.changeUserRole(request.json, dynamoDBInstance)
     if res.hasErrors():
       status = 400
+  return ResponseCreation.createResponse(res,status)
+
+@app.route('/ms-test/', methods=['POST', 'OPTIONS'])
+def mathsteps():
+  status = 200
+  if request.method =='OPTIONS':
+    return ResponseCreation.createEmptyResponse(status)
+  res = ResponseCreation.ControllerResponse()
+  problem = request.json['problem']
+  steps = mathstepsWrapper.getStepsForProblem(problem)
+  res.addToPayload('steps', steps)
+  if res.hasErrors():
+    status = 400
   return ResponseCreation.createResponse(res,status)
 
 if __name__ == '__main__':

--- a/Backend/config/config.js.donotuse
+++ b/Backend/config/config.js.donotuse
@@ -1,0 +1,3 @@
+module.exports = {
+    "path": "/my/exact/path/to/mathstep/folder/node_modules/"
+};

--- a/Backend/config/devConfig.donotuse
+++ b/Backend/config/devConfig.donotuse
@@ -7,5 +7,3 @@ isProd: False
 appSecret: askjonnyboy
 [MentiiData]
 path: /path/path/mentii
-[MathstepsLocation]
-path: /path/to/mathsteps

--- a/Backend/deploy.wsgi
+++ b/Backend/deploy.wsgi
@@ -8,6 +8,9 @@ site.addsitedir(os.path.join(os.path.dirname(__file__),     'env/local/lib/pytho
 # Path of execution
 sys.path.append('/var/www/html/Backend')
 
+#Add usr/local/bin
+os.environ['PATH'] += ':/usr/local/bin'
+
 # Fired up virtualenv before include application
 activate_env = os.path.expanduser(os.path.join(os.path.dirname(__file__), 'env/bin/activate_this.py'))
 execfile(activate_env, dict(__file__=activate_env))

--- a/Backend/problems/index.js
+++ b/Backend/problems/index.js
@@ -1,0 +1,20 @@
+/*jshint esversion: 6 */
+const config = require('/config/config.js');
+const mathsteps = require(config.path + 'mathsteps');
+const problem = process.argv[2];
+const steps = mathsteps.solveEquation(problem);
+
+var responseSteps = [];
+steps.forEach( step => {
+  if(step.substeps.length > 1) {
+    step.substeps.forEach( subStep => {
+      responseSteps.push(subStep.newEquation.print());
+    }
+  );
+}
+responseSteps.push(step.newEquation.print());
+});
+
+var json = JSON.stringify(responseSteps);
+console.log(json);
+process.exit(0);

--- a/Backend/problems/mathstepsWrapper.py
+++ b/Backend/problems/mathstepsWrapper.py
@@ -1,59 +1,10 @@
 #!/usr/bin/env python
 import subprocess
 import os
-
-JAVASCRIPT_FIRSTLINE="const mathsteps = require('mathsteps');\n"
-JAVASCRIPT_PROBLEMLINE="const steps = mathsteps.solveEquation('{0}');\n"
-JAVASCRIPT_PRINTLINE='''steps.forEach(
-  step => 
-    { if(step.substeps.length > 1)
-      { step.substeps.forEach(
-          subStep => console.log(subStep.newEquation.print())
-        ) 
-      }\n 
-      console.log(step.newEquation.print()); 
-    });\n'''
-
-JAVASCRIPT_FILEPATH='mentii.js'
-JAVASCRIPT_OUTPUTPATH='mentii_output.txt'
-
-'''
-NOTE: 
-
-  It looks like the mathsteps needs to be installed where ever the 
-  javascript file is executed. This means we can have a special 
-  place on the server that has mathsteps and we just write and run the
-  script there. 
-'''
-
-def setMathstepsLocation(path):
-  global JAVASCRIPT_FILEPATH
-  #Set a global variable for the javacript path... 
-  JAVASCRIPT_FILEPATH = path + "/mentii.js"
-
- 
-def _writeProblemFile(problem, filename):
-  with open(filename, 'w') as f:
-    f.write(JAVASCRIPT_FIRSTLINE)
-    f.write(JAVASCRIPT_PROBLEMLINE.format(problem))
-    f.write(JAVASCRIPT_PRINTLINE)
-
+import json
 
 def getStepsForProblem(problem):
-  _writeProblemFile(problem, JAVASCRIPT_FILEPATH)
-  with open(JAVASCRIPT_OUTPUTPATH, 'w') as f:
-    subprocess.call(['node', JAVASCRIPT_FILEPATH], stdout=f)
-  
-  problemSteps = [problem]
-  with open(JAVASCRIPT_OUTPUTPATH, 'r') as f:
-    for line in f:
-      cleanLine = line.strip()
-      if cleanLine != problemSteps[-1]:
-        problemSteps.append(cleanLine)
-
-  #Clean up the tmp files
-  os.remove(JAVASCRIPT_FILEPATH)
-  os.remove(JAVASCRIPT_OUTPUTPATH)
-
+  mathstepsFile = os.path.dirname(os.path.abspath(__file__)) + "/index.js"
+  problemStepsJson = subprocess.check_output(['node', mathstepsFile, problem])
+  problemSteps = json.loads(problemStepsJson)
   return problemSteps
-

--- a/Backend/tests/notTest_algebra.py
+++ b/Backend/tests/notTest_algebra.py
@@ -8,6 +8,7 @@ from problems import mathstepsWrapper
 class MentiiMathstepsTests(unittest.TestCase):
 
   def test_getStepsForProblem(self):
+    print('Running getStepsForProblem test case')
     problem1 = "5x=10"
     problem2 = "3x+2x=5*2"
     sol1 = [u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']

--- a/Backend/tests/notTest_algebra.py
+++ b/Backend/tests/notTest_algebra.py
@@ -1,29 +1,17 @@
 import unittest
 import sys
 from os import path
-import ConfigParser as cp
 sys.path.append( path.dirname( path.dirname( path.abspath(__file__) ) ) )
 from problems import mathstepsWrapper
 
 
-#Configuration setup
-configPath = "/config/prodConfig.ini"
-parser = cp.ConfigParser()
-parser.read(configPath)
-
-mathstepsPath = parser.get("MathstepsLocation", 'path')
-
 class MentiiMathstepsTests(unittest.TestCase):
-
-  @classmethod
-  def setUpClass(self):
-    mathstepsWrapper.setMathstepsLocation(mathstepsPath)
 
   def test_getStepsForProblem(self):
     problem1 = "5x=10"
     problem2 = "3x+2x=5*2"
-    sol1 = ['5x=10', '(5x) / 5 = 10/5', 'x = 10/5', 'x = 2']
-    sol2 = ['3x+2x=5*2', '(3 + 2)x = 5 * 2', '5x = 5 * 2', '5x = 10', '(5x) / 5 = 10/5', 'x = 10/5', 'x = 2']
+    sol1 = [u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']
+    sol2 = [u'(3 + 2)x = 5 * 2', u'5x = 5 * 2',  u'5x = 5 * 2', u'5x = 10', u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']
     steps = mathstepsWrapper.getStepsForProblem(problem1)
     self.assertEqual(sol1, steps)
     steps = mathstepsWrapper.getStepsForProblem(problem2)

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",


### PR DESCRIPTION
Problem steps can now be acquired by passing the problem as an argument to a javascript file called with node.

**Significant Changes**
1. Path to mathsteps library is removed from the prodConfig.ini file 😄 
2. Path to mathsteps library is added in a new config file called config.js 😭 _(more about this in the notes section)_
3. Endpoint was added for easy testing. The rest call has an attribute "problem" in the post body

**How to Test**
1. Remove the mathsteps stuff from your config.ini file
2. Create a new `config.js` file in the `/config/` directory. This file will be set up the same as `Backend/config/config.js.donotuse`. Make sure the path is to the node_modules directory where mathsteps is installed. Also be sure that the path has the trailing /.
3. modify Backend/tests/notTest_algebra.py to Backend/tests/test_algebra.py and run `make runtests` in backedn
4. Start up the backend and make a POST request to /ms-test with a problem attribute in the body. Specify the problem to solve here.
5. Read line 8 of Backend/problems/mathstepsWrapper.py to see how it is being passed as an argument to node.

**Notes**
I needed to create a new json based config file to be able to include the mathsteps path in the javascript file I made. Without this, the javascript file would not know where the library is located. The alternative would be to include a package.json in Backend and then install mathsteps each time we deploy but I felt like this option was even worse than a new config file. Let me know your thoughts/questions.