### PR TITLE
Bug 144

### DIFF
--- a/Backend/problems/index.js
+++ b/Backend/problems/index.js
@@ -5,12 +5,14 @@ const problem = process.argv[2];
 const steps = mathsteps.solveEquation(problem);
 
 var responseSteps = [];
+responseSteps.push(problem)
 steps.forEach( step => {
   if(step.substeps.length > 1) {
     step.substeps.forEach( subStep => {
       responseSteps.push(subStep.newEquation.print());
     }
   );
+  return;
 }
 responseSteps.push(step.newEquation.print());
 });

--- a/Backend/tests/notTest_algebra.py
+++ b/Backend/tests/notTest_algebra.py
@@ -11,8 +11,8 @@ class MentiiMathstepsTests(unittest.TestCase):
     print('Running getStepsForProblem test case')
     problem1 = "5x=10"
     problem2 = "3x+2x=5*2"
-    sol1 = [u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']
-    sol2 = [u'(3 + 2)x = 5 * 2', u'5x = 5 * 2',  u'5x = 5 * 2', u'5x = 10', u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']
+    sol1 = [u'5x=10', u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']
+    sol2 = [u'3x+2x=5*2',u'(3 + 2)x = 5 * 2', u'5x = 5 * 2', u'5x = 10', u'(5x) / 5 = 10/5', u'x = 10/5', u'x = 2']
     steps = mathstepsWrapper.getStepsForProblem(problem1)
     self.assertEqual(sol1, steps)
     steps = mathstepsWrapper.getStepsForProblem(problem2)

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",


### PR DESCRIPTION
Change:

- Mathsteps wrapper shouldn't return duplicate steps any more. 
- The original problem is at the beginning of the list. 

Test:

Use the endpoint that was made or a python terminal to call the getStepsForProblem method from the mathsteps wrapper and see that there are no longer duplicate entries and the first element is the problem that was passed in. 