### PR TITLE
Adds footer to site

### DIFF
--- a/Frontend/app/styles/style.css
+++ b/Frontend/app/styles/style.css
@@ -1,6 +1,27 @@
+html, body {
+  height: 100%;
+  margin: 0;
+}
+
 body {
   padding-top: 70px;
-  padding-bottom: 50px;
+}
+
+.content {
+  min-height: 100%;
+}
+.content-inside {
+  padding-bottom: 102px;
+}
+.footer {
+  height: 102px;
+  margin-top: -102px;
+  padding-top: 50px;
+}
+
+.footer .navbar {
+  border-radius: 0;
+  margin-bottom: 0;
 }
 
 .navbar-default .navbar-brand {

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -60,14 +60,28 @@
 </head>
 <!-- 3. Display the application -->
 <body>
-  <my-app>
-    <div class="loading" style="margin: 0 auto; text-align: center; margin-top: 15%; color: #777;">
-      <h3><i class="fa fa-spinner fa-2x fa-spin" aria-hidden="true"></i></h3>
-      <h1>loading mentii</h1>
+  <div class="content">
+    <div class="content-inside">
+      <my-app>
+        <div class="loading" style="margin: 0 auto; text-align: center; margin-top: 15%; color: #777;">
+          <h3><i class="fa fa-spinner fa-2x fa-spin" aria-hidden="true"></i></h3>
+          <h1>loading mentii</h1>
+        </div>
+      </my-app>
     </div>
-  </my-app>
+  </div>
+  <footer class="footer">
+    <nav class="navbar navbar-default text-muted text-center">
+      <div class="container">
+        <p class="navbar-text">
+          <em>v<span id="version"></span></em> | MIT License | <a href="https://github.com/mentii/mentii" target="_blank">View the Source Code on Github</a>
+        </p>
+      </div>
+    </nav>
+  </footer>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
   <!-- Include all compiled plugins (below), or include individual files as needed -->
   <script src="vendor/bootstrap/js/bootstrap.min.js"></script>
+  <script src="package.json.service.js"></script>
 </body>
 </html>

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -74,7 +74,7 @@
     <nav class="navbar navbar-default text-muted text-center">
       <div class="container">
         <p class="navbar-text">
-          <em>v<span id="version"></span></em> | MIT License | <a href="https://github.com/mentii/mentii" target="_blank">View the Source Code on Github</a>
+          <em>v<span id="version"></span></em> | <a href="https://github.com/mentii/mentii/blob/master/LICENSE" target="_blank">MIT License</a> | <a href="https://github.com/mentii/mentii" target="_blank">View the Source Code on Github</a>
         </p>
       </div>
     </nav>

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.7.10",
+  "version": "0.8.1",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",

--- a/Frontend/package.json.service.js
+++ b/Frontend/package.json.service.js
@@ -1,0 +1,5 @@
+$(document).ready(function(){
+  $.getJSON( "./package.json", function( data ) {
+    $("#version").text(data.version);
+  });
+});


### PR DESCRIPTION
Adds a footer to the site showing the version number in the package.json, the license and a link to the github repo

**Significant Changes**
1. Adds footer to all pages
2. Adds a new jquery file that lives outside of the app context to retrieve the package.json as data

**How to Test**
1. Go to [stapp.mentii.me](http://stapp.mentii.me) and look for the footer at the bottom of the page
2. If running locally you can test changing the value of the version in package.json to see it change. This will only update on a refresh or new load of the site.