### PR TITLE
Save the logs

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -27,7 +27,7 @@ parser = cp.ConfigParser()
 parser.read(configPath)
 
 #Setup logfile
-logPath = parser.get('MentiiData', 'path') + '/logs'
+logPath = parser.get('LogfileLocation', 'path') + '/logs'
 MentiiLogging.setupLogger(logPath)
 logger = MentiiLogging.getLogger()
 

--- a/Backend/config/devConfig.donotuse
+++ b/Backend/config/devConfig.donotuse
@@ -5,5 +5,5 @@ Password: FakePassword
 isProd: False
 [MentiiAuthentication]
 appSecret: askjonnyboy
-[MentiiData]
+[Logfile Location]
 path: /path/path/mentii

--- a/Backend/config/devConfig.donotuse
+++ b/Backend/config/devConfig.donotuse
@@ -5,5 +5,5 @@ Password: FakePassword
 isProd: False
 [MentiiAuthentication]
 appSecret: askjonnyboy
-[Logfile Location]
+[LogfileLocation]
 path: /path/path/mentii

--- a/Backend/utils/MentiiLogging.py
+++ b/Backend/utils/MentiiLogging.py
@@ -2,12 +2,13 @@ import os
 import time
 import logging
 from logging.handlers import TimedRotatingFileHandler
+from datetime import datetime
 
 FILE = '/mentiilog.log'
 
 def setupLogger(path):
   path += FILE
-  confirmLogDir(path)
+  prepareLogfile(path)
 
   logger = logging.getLogger('Backend')
   logger.setLevel(logging.DEBUG)
@@ -23,10 +24,16 @@ def setupLogger(path):
   formatter = logging.Formatter('[%(levelname)-8s][%(name)-8s][%(asctime)s] : %(message)s')
   handler.setFormatter(formatter)
   logger.addHandler(handler)
+  logger.info("Logfile Created.")
 
 def getLogger():
   return logging.getLogger('Backend')
 
-def confirmLogDir(path):
+def prepareLogfile(path):
   if not os.path.exists(os.path.dirname(path)):
     os.makedirs(os.path.dirname(path))
+  elif os.path.isfile(path):
+    # Rename old logfile
+    modifiedTime = os.path.getmtime(path) 
+    timeStamp =  datetime.fromtimestamp(modifiedTime).strftime("%b-%d-%y-%H:%M:%S")
+    os.rename(path,path+".old."+timeStamp)

--- a/Backend/utils/MentiiLogging.py
+++ b/Backend/utils/MentiiLogging.py
@@ -1,5 +1,4 @@
 import os
-import time
 import logging
 from logging.handlers import TimedRotatingFileHandler
 from datetime import datetime


### PR DESCRIPTION
Moves the logfile out of mentii dir to /var/log/mentii and makes required changes
2 story points

**Significant Changes**
1. Moves logfile out of mentii directory
2. Adds a timestamp when file is created
3. (mistake, already merged) Logfile is set up earlier in app.py
4. Because we are NOT passing branch to app.py, I made a nice alias called 'branch' that tells you the branch on the deployed server.

**How to Test**
1. Go to stapp server and look at how mentii no longer has logs directory and /var/log/mentii does and the file backups occuring.