### PR TITLE
Bug 101

### DIFF
--- a/Backend/utils/MentiiAuth.py
+++ b/Backend/utils/MentiiAuth.py
@@ -24,7 +24,7 @@ def userDataValid(userData):
   return (  'email' in userData.keys() and userData['email'] and
             'userRole' in userData.keys() and userData['userRole'] )
 
-def generateAuthToken(userCredentials, appSecret=None, expiration = 86400):
+def generateAuthToken(userCredentials, appSecret=None, expiration = 60):
   '''
   Generates the auth token based off of the user's email and password with a default expiration duration.
   Default token will last 1 day.

--- a/Backend/utils/MentiiAuth.py
+++ b/Backend/utils/MentiiAuth.py
@@ -24,7 +24,7 @@ def userDataValid(userData):
   return (  'email' in userData.keys() and userData['email'] and
             'userRole' in userData.keys() and userData['userRole'] )
 
-def generateAuthToken(userCredentials, appSecret=None, expiration = 60):
+def generateAuthToken(userCredentials, appSecret=None, expiration = 86400):
   '''
   Generates the auth token based off of the user's email and password with a default expiration duration.
   Default token will last 1 day.

--- a/Frontend/app/admin/admin.component.ts
+++ b/Frontend/app/admin/admin.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RoleModel } from './role.model';
 import { UserService } from '../user/user.service';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 
 @Component({
   moduleId: module.id,
@@ -13,7 +13,7 @@ export class AdminComponent {
   model = new RoleModel('','student');
   isLoading = false;
 
-  constructor(public userService: UserService, public toastr: ToastsManager){
+  constructor(public userService: UserService, public toastr: ToastrService){
   }
 
   newModel() {

--- a/Frontend/app/app.component.ts
+++ b/Frontend/app/app.component.ts
@@ -1,6 +1,6 @@
 // ====== ./app/app.component.ts ======
-import { Component, ViewContainerRef, OnInit } from '@angular/core';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { Component, OnInit } from '@angular/core';
+import { ToastrService } from 'ngx-toastr';
 import { AuthHttp } from './utils/AuthHttp.service';
 import { Router } from '@angular/router';
 
@@ -16,8 +16,7 @@ export class AppComponent implements OnInit {
   isAuthenticated = false;
   role;
 
-  constructor(public toastr: ToastsManager, public authHttpService: AuthHttp, public router: Router, vRef: ViewContainerRef) {
-    this.toastr.setRootViewContainerRef(vRef);
+  constructor(public toastr: ToastrService, public authHttpService: AuthHttp, public router: Router) {
   }
 
   ngOnInit() {
@@ -36,7 +35,7 @@ export class AppComponent implements OnInit {
         this.role = data;
       }
     );
-    
+
     // Initialize the check on the role and authentication
     // Used mostly when opening the app to a weird page such as /create/class directly
     this.authHttpService.propagateRole();

--- a/Frontend/app/app.module.ts
+++ b/Frontend/app/app.module.ts
@@ -11,7 +11,7 @@ import { routing } from './app.routes';
 /* Services */
 import { UserService } from './user/user.service';
 import { ClassService } from './class/class.service';
-import { ToastModule } from 'ng2-toastr/ng2-toastr';
+import { ToastrModule } from 'ngx-toastr';
 /* Components */
 import { AdminComponent } from './admin/admin.component';
 import { AppComponent } from './app.component';
@@ -45,7 +45,7 @@ import { LaddaModule } from 'angular2-ladda';
     BrowserModule,
     FormsModule,
     HttpModule,
-    ToastModule,
+    ToastrModule.forRoot({preventDuplicates: true}),
     LaddaModule.forRoot({style: "zoom-in"}),
     routing,
     CommonModule,

--- a/Frontend/app/class/browse/browse.component.ts
+++ b/Frontend/app/class/browse/browse.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ClassModel } from '../class.model';
 import { ClassService } from '../class.service';
 import { UserService } from '../../user/user.service';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { Router } from '@angular/router'
 
 
@@ -17,7 +17,7 @@ export class ClassBrowseComponent implements OnInit {
   classes: ClassModel[] = [];
   isJoinClassInprogress = false;
 
-  constructor(public classService: ClassService, public toastr: ToastsManager, public router: Router, public userService: UserService ){
+  constructor(public classService: ClassService, public toastr: ToastrService, public router: Router, public userService: UserService ){
   }
 
   ngOnInit() {

--- a/Frontend/app/class/create/create.component.ts
+++ b/Frontend/app/class/create/create.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { ClassModel } from '../class.model';
 import { Router } from '@angular/router';
 import { ClassService } from '../class.service';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 
 @Component({
   moduleId: module.id,
@@ -14,7 +14,7 @@ export class CreateClassComponent {
   model = new ClassModel('', '', '', '', '', [], []);
   isLoading = false;
 
-  constructor(public classService: ClassService, public toastr: ToastsManager, public router: Router){
+  constructor(public classService: ClassService, public toastr: ToastrService, public router: Router){
   }
 
   submit() {

--- a/Frontend/app/class/detail/detail.component.ts
+++ b/Frontend/app/class/detail/detail.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 import { ClassService } from '../class.service';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { ClassModel } from '../class.model';
 
 @Component({
@@ -21,7 +21,7 @@ export class ClassDetailComponent implements OnInit, OnDestroy {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private classService: ClassService,
-    private toastr: ToastsManager
+    private toastr: ToastrService
   ){}
 
   ngOnInit() {

--- a/Frontend/app/class/list/list.component.ts
+++ b/Frontend/app/class/list/list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ClassModel } from '../class.model';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { ClassService } from '../class.service';
 
 @Component({
@@ -13,7 +13,7 @@ export class ClassListComponent implements OnInit {
   classes: ClassModel[] = [];
   isLoading = true;
 
-  constructor(public classService: ClassService, public toastr: ToastsManager){
+  constructor(public classService: ClassService, public toastr: ToastrService){
   }
 
   ngOnInit() {

--- a/Frontend/app/class/list/list.component.ts
+++ b/Frontend/app/class/list/list.component.ts
@@ -31,8 +31,10 @@ export class ClassListComponent implements OnInit {
 
   handleError(err){
     this.isLoading = false;
-    if (!err.isAuthenticationError) {
-      this.toastr.error("The class list failed to load.");
+    console.log("Class List component")
+    console.log(err)
+    if (err.isAuthenticationError == false) {
+      this.toastr.error("The class list component failed to load.");
     }
   }
 

--- a/Frontend/app/class/list/list.component.ts
+++ b/Frontend/app/class/list/list.component.ts
@@ -31,8 +31,6 @@ export class ClassListComponent implements OnInit {
 
   handleError(err){
     this.isLoading = false;
-    console.log("Class List component")
-    console.log(err)
     if (err.isAuthenticationError == false) {
       this.toastr.error("The class list component failed to load.");
     }

--- a/Frontend/app/class/listItem/classListItem.component.ts
+++ b/Frontend/app/class/listItem/classListItem.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Router } from '@angular/router';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { UserService } from '../../user/user.service';
 
 @Component({
@@ -15,7 +15,7 @@ export class ClassListItemComponent {
   @Input() joinClassButtonShown;
   isJoinClassInprogress = false;
 
-  constructor(public toastr: ToastsManager, public router: Router, public userService: UserService ){
+  constructor(public toastr: ToastrService, public router: Router, public userService: UserService ){
   }
 
   joinClass(classCode) {

--- a/Frontend/app/class/taughtList/taughtList.component.ts
+++ b/Frontend/app/class/taughtList/taughtList.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ClassModel } from '../class.model';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { ClassService } from '../class.service';
 
 @Component({
@@ -13,7 +13,7 @@ export class TaughtClassListComponent implements OnInit {
   classes: ClassModel[] = [];
   isLoading = true;
 
-  constructor(public classService: ClassService, public toastr: ToastsManager){
+  constructor(public classService: ClassService, public toastr: ToastrService){
   }
 
   ngOnInit() {

--- a/Frontend/app/class/taughtList/taughtList.component.ts
+++ b/Frontend/app/class/taughtList/taughtList.component.ts
@@ -31,8 +31,6 @@ export class TaughtClassListComponent implements OnInit {
 
   handleError(err){
     this.isLoading = false;
-    console.log("TaughList")
-    console.log(err)
     if (err.isAuthenticationError == false) {
       this.toastr.error("The taught class list failed to load.");
     }

--- a/Frontend/app/class/taughtList/taughtList.component.ts
+++ b/Frontend/app/class/taughtList/taughtList.component.ts
@@ -31,8 +31,10 @@ export class TaughtClassListComponent implements OnInit {
 
   handleError(err){
     this.isLoading = false;
-    if (!err.isAuthenticationError) {
-      this.toastr.error("The class list failed to load.");
+    console.log("TaughList")
+    console.log(err)
+    if (err.isAuthenticationError == false) {
+      this.toastr.error("The taught class list failed to load.");
     }
   }
 

--- a/Frontend/app/core.module.ts
+++ b/Frontend/app/core.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { HttpModule, RequestOptions, XHRBackend } from '@angular/http';
 import { Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { AuthHttp } from './utils/AuthHttp.service';
 
 /*
@@ -17,10 +17,10 @@ Things imported in this module are singletons for the entire app
   providers: [
     {
       provide: AuthHttp,
-      useFactory: (backend: XHRBackend, options: RequestOptions, router: Router, toastr: ToastsManager) => {
+      useFactory: (backend: XHRBackend, options: RequestOptions, router: Router, toastr: ToastrService) => {
         return new AuthHttp(backend, options, router, toastr);
       },
-      deps: [XHRBackend, RequestOptions, Router, ToastsManager]
+      deps: [XHRBackend, RequestOptions, Router, ToastrService]
     }
   ]
 })

--- a/Frontend/app/problem/display/displayProblem.component.ts
+++ b/Frontend/app/problem/display/displayProblem.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ProblemService } from '../problem.service';
 import { UserService } from '../../user/user.service';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { ActivatedRoute } from '@angular/router';
 import { Router } from '@angular/router'
 
@@ -32,7 +32,7 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
   badStepShown = false;
   problemIsComplete = false;
 
-  constructor(public problemService: ProblemService, public toastr: ToastsManager, public router: Router, private activatedRoute: ActivatedRoute){
+  constructor(public problemService: ProblemService, public toastr: ToastrService, public router: Router, private activatedRoute: ActivatedRoute){
   }
 
   showNextStep(){

--- a/Frontend/app/secureTest/secureTest.component.ts
+++ b/Frontend/app/secureTest/secureTest.component.ts
@@ -3,7 +3,7 @@ import { Response, Headers, RequestOptions } from "@angular/http";
 import { AuthHttp } from '../utils/AuthHttp.service';
 import { Router } from '@angular/router';
 import { MentiiConfig } from '../mentii.config';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 
 @Component({
   moduleId: module.id,
@@ -13,7 +13,7 @@ import { ToastsManager } from 'ng2-toastr/ng2-toastr';
 export class SecureTestComponent {
   mentiiConfig = new MentiiConfig();
 
-  constructor(public http: AuthHttp, public router: Router, public toastr: ToastsManager){
+  constructor(public http: AuthHttp, public router: Router, public toastr: ToastrService){
     this.testToken();
   }
 

--- a/Frontend/app/user/registration/registration.component.ts
+++ b/Frontend/app/user/registration/registration.component.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { RegistrationModel } from './registration.model';
 import { MentiiConfig } from '../../mentii.config';
 import { UserService } from '../user.service';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 
 @Component({
   moduleId: module.id,
@@ -16,7 +16,7 @@ export class RegistrationComponent {
   regSuccess = false;
   isLoading = false;
 
-  constructor(public userService: UserService, public toastr: ToastsManager){
+  constructor(public userService: UserService, public toastr: ToastrService){
   }
 
   newModel() {

--- a/Frontend/app/user/signin/signin.component.ts
+++ b/Frontend/app/user/signin/signin.component.ts
@@ -3,7 +3,7 @@ import { Component } from '@angular/core';
 import { MentiiConfig } from '../../mentii.config';
 import { Router } from '@angular/router';
 import { SigninModel } from './signin.model';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 import { UserService } from '../user.service';
 
 @Component({
@@ -17,7 +17,7 @@ export class SigninComponent {
   mentiiConfig = new MentiiConfig();
   isLoading = false;
 
-  constructor(public userService: UserService, public authHttpService: AuthHttp , public router: Router, public toastr: ToastsManager){
+  constructor(public userService: UserService, public authHttpService: AuthHttp , public router: Router, public toastr: ToastrService){
   }
 
   handleSuccess(data) {

--- a/Frontend/app/utils/AuthHttp.service.ts
+++ b/Frontend/app/utils/AuthHttp.service.ts
@@ -5,7 +5,7 @@ import { Router } from '@angular/router';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
-import { ToastsManager } from 'ng2-toastr/ng2-toastr';
+import { ToastrService } from 'ngx-toastr';
 
 
 const AUTH_TOKEN_NAME = "auth_token";
@@ -26,7 +26,7 @@ export class AuthHttp extends Http {
   private _role = new BehaviorSubject<string>('student');
   role$ = this._role.asObservable();
 
-  constructor (backend: XHRBackend, options: RequestOptions, private router: Router, public toastr: ToastsManager ) {
+  constructor (backend: XHRBackend, options: RequestOptions, private router: Router, public toastr: ToastrService ) {
     super(backend, options);
   }
 

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -46,7 +46,6 @@
   <script src="node_modules/zone.js/dist/zone.js"></script>
   <script src="node_modules/reflect-metadata/Reflect.js"></script>
   <script src="node_modules/systemjs/dist/system.src.js"></script>
-  <script src="node_modules/ng2-toastr/bundles/ng2-toastr.min.js"></script>
   <!-- 2. Configure SystemJS -->
   <script src="systemjs.config.js"></script>
   <script>System.import('app').catch(function(err){ console.error(err); });</script>

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -35,7 +35,7 @@
   <link rel="stylesheet" href="vendor/fontawesome/css/font-awesome.min.css">
   <link rel="stylesheet" href="app/styles/forms.css">
   <link rel="stylesheet" href="app/styles/style.css">
-  <link href="node_modules/ng2-toastr/bundles/ng2-toastr.min.css" rel="stylesheet" />
+  <link href="node_modules/ngx-toastr/toastr.css" rel="stylesheet" />
   <link rel="stylesheet" href="app/styles/toastr-override.css">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i|Raleway:400,400i,700,700i" rel="stylesheet">
 

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -31,7 +31,7 @@
     "angular2-ladda": "1.0.7",
     "bootstrap": "3.3.7",
     "core-js": "2.4.1",
-    "ng2-toastr": "1.3.6",
+    "ngx-toastr": "4.3.0",
     "reflect-metadata": "0.1.9",
     "rxjs": "5.1.1",
     "systemjs": "0.20.9",

--- a/Frontend/systemjs.config.js
+++ b/Frontend/systemjs.config.js
@@ -30,6 +30,7 @@
       'angular2-ladda':             'node_modules/angular2-ladda',
       'ladda':                      'node_modules/ladda/js',
       'spin':                       'node_modules/ladda/js/spin.js',
+      'ngx-toastr': 'node_modules/ngx-toastr/toastr.umd.js',
     },
     // packages tells the System loader how to load when no filename and/or no extension
     packages: {


### PR DESCRIPTION
Stops the 'Class list failed to load toasts from occurring on expired authentications.

**Significant Changes**
1. No longer displays unwanted toasts
2. Duplicate toasts are not shown
3. Swapped ng2-toastr for ngx-toastr

**How to Test**
1. Change the expiration time in MentiiAuth to say, a minute (60) and build mentii.
2. Login with some account.
3. Close the browser and all xterms, re-make Mentii and try signing in with the same account and you should only see one toast now.