### PR TITLE
Set bad step limit to one

### DIFF
--- a/Frontend/app/problem/display/displayProblem.component.ts
+++ b/Frontend/app/problem/display/displayProblem.component.ts
@@ -44,8 +44,8 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
   showBadStepColor = false;
   panelClass = 'panel panel-default';
 
-  //default all bad steps in tree are shown
-  selectedStepLimit = -1;
+  //default show only one bad step
+  selectedStepLimit = 1;
   stepLimit = 0;
 
   constructor(public problemService: ProblemService, public toastr: ToastrService, public router: Router, private activatedRoute: ActivatedRoute){
@@ -128,7 +128,7 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
     this.problemService.postProblemSuccess(this.classCode, this.problemCode, this.problemIndex, "True")
       .subscribe();
   }
-  
+
   sendFailUpdate() {
     this.problemService.postProblemSuccess(this.classCode, this.problemCode, this.problemIndex, "")
       .subscribe();

--- a/Frontend/app/problem/display/displayProblem.html
+++ b/Frontend/app/problem/display/displayProblem.html
@@ -12,7 +12,7 @@
         </button>
       <label for="stepLimit">Bad Step Limit</label>
       <span class="dropdown">
-        <button id="stepLimit" type="button" class="btn btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        <button disabled id="stepLimit" type="button" class="btn btn-default" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
           <span *ngIf="selectedStepLimit < 0">&infin;&nbsp;</span>
           <span *ngIf="selectedStepLimit > 0">{{selectedStepLimit}}&nbsp;</span>
           <span class="caret"></span>

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.12.2",
+  "version": "0.12.4",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",


### PR DESCRIPTION
**Significant Changes**
1. Sets bad step limit to one for all bad steps, disables configuration

**How to Test**
1. Do a problem
2. Make sure that only one bad step is shown and when you press continue the "Uh Oh" toast appears

**Notes**
Will increment version number before merge