### PR TITLE
Moved edit class details button

### DIFF
--- a/Frontend/app/class/detail/detail.html
+++ b/Frontend/app/class/detail/detail.html
@@ -81,7 +81,7 @@
         </div>
         <div class="row">
           <div class="col-xs-12">
-            <button class="btn btn-default" (click)="toggleEditMode()">Edit Class Information</button>
+            <button class="btn btn-default" (click)="toggleEditMode()">Edit Class Details</button>
           </div>
         </div>
         <div class="row">

--- a/Frontend/app/class/detail/detail.html
+++ b/Frontend/app/class/detail/detail.html
@@ -6,7 +6,6 @@
   <!-- Only show if the api done loading -->
   <div class="col-xs-12 col-md-8" *ngIf="!isLoading && !editMode">
     <div class="row">
-      <button *ngIf="showTeacherView" class="btn btn-default pull-right" (click)="toggleEditMode()">Edit Class</button>
       <div class="col-xs-12">
         <h2>
           {{model.title}}
@@ -78,6 +77,11 @@
                 This panel is only visible to the teacher of this class.
               </em>
             </p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-xs-12">
+            <button class="btn btn-default" (click)="toggleEditMode()">Edit Class Information</button>
           </div>
         </div>
         <div class="row">

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.12.2",
+  "version": "0.12.1",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",


### PR DESCRIPTION
**Significant Changes**
1. Moved edit class details button to teacher panel

**How to Test**
1. Login with teacher privileges
2. Create a class
3. Confirm button is now in teacher panel and edit class functionality is the same

**Notes**
Clicking on the button again after the Edit Class Details Page is shown will discard any current changes in the form and will hide the edit page

Will edit version number before merge