### PR TITLE
Edit class details on dash board

### DIFF
--- a/Frontend/app/app.routes.ts
+++ b/Frontend/app/app.routes.ts
@@ -33,10 +33,10 @@ export const routes: Routes = [
   { path: 'reset-password/:id', component: ResetPasswordComponent },
   { path: 'activation/:id', component: ActivationComponent},
   { path: 'dashboard', component: DashboardComponent, canActivate: [AuthRouteGuard] },
-  { path: 'class', component: ClassBrowseComponent, canActivate: [AuthRouteGuard] },
   { path: 'class/:id', component: ClassDetailComponent, canActivate: [AuthRouteGuard] },
-  { path: 'admin', component: AdminComponent, canActivate: [AuthRouteGuard, AdminRouteGuard]},
+  { path: 'class', component: ClassBrowseComponent, canActivate: [AuthRouteGuard] },
   { path: 'admin/:control', component: AdminComponent, canActivate: [AuthRouteGuard, AdminRouteGuard]},
+  { path: 'admin', component: AdminComponent, canActivate: [AuthRouteGuard, AdminRouteGuard]},
   { path: 'create/class', component: CreateClassComponent, canActivate: [AuthRouteGuard, TeacherRouteGuard] },
   { path: 'problem/display/:classCode/:problemCode', component: DisplayProblemComponent, canActivate: [AuthRouteGuard] },
 

--- a/Frontend/app/class/detail/detail.component.ts
+++ b/Frontend/app/class/detail/detail.component.ts
@@ -27,6 +27,12 @@ export class ClassDetailComponent implements OnInit, OnDestroy {
   ){}
 
   ngOnInit() {
+    this.activatedRoute.queryParams.subscribe(qParams => {
+      if(qParams['edit'] == 'true') {
+        this.editMode = true;
+      }
+    });
+
     this.routeSub = this.activatedRoute.params.subscribe(params => {
       this.model.code = params['id'];
       this.classService.getClass(this.model.code)

--- a/Frontend/app/class/listItem/classListItem.component.ts
+++ b/Frontend/app/class/listItem/classListItem.component.ts
@@ -13,6 +13,7 @@ export class ClassListItemComponent {
   @Input() classObject;
   @Input() classDetailsButton;
   @Input() joinClassButtonShown;
+  @Input() editClassButtonShown;
   isJoinClassInprogress = false;
 
   constructor(public toastr: ToastrService, public router: Router, public userService: UserService ){

--- a/Frontend/app/class/listItem/classListItem.html
+++ b/Frontend/app/class/listItem/classListItem.html
@@ -13,6 +13,7 @@
     <button class="btn btn-sm btn-primary" (click)="joinClass(classObject.code)" *ngIf="joinClassButtonShown" [ladda]="isJoinClassInprogress">
       Join {{classObject.title}}
     </button>
-    <a [routerLink]="['/class/', classObject.code]" class="btn btn-sm btn-info">View Class Detail Page</a>
+    <a [routerLink]="['/class/', classObject.code]" class="btn btn-sm btn-info">View Class Details</a>
+    <a *ngIf="editClassButtonShown" [routerLink]="['/class/', classObject.code]" [queryParams]="{edit:true}" class="btn btn-sm btn-info">Edit Class Details</a>
   </div>
 </div>

--- a/Frontend/app/class/taughtList/taughtList.html
+++ b/Frontend/app/class/taughtList/taughtList.html
@@ -15,7 +15,7 @@
     </div>
     <div class="row" *ngFor="let class of classes;">
       <div class="col-xs-12">
-        <class-list-item [classObject]="class"></class-list-item>
+        <class-list-item [editClassButtonShown]="true" [classObject]="class"></class-list-item>
       </div>
     </div>
   </div>

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.12.5",
+  "version": "0.12.6",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",


### PR DESCRIPTION
Allows a teacher to go to edit their class details from their dashboard

**Significant Changes**
1. Adds a button for a teacher's class that takes them to the edit class details page when clicked
2. Reordered some routes (based on Angular documentation recommending more specific to least)

**How to Test**
1. Login with teacher privileges
2. Create a Class
3. See the **Edit Class Details** button added on the teacher dashboard
4. Go to **View Public Classes** and confirm **Edit Class Details**
5. Copy URL
6. Login as another teacher and confirm the **Edit Class Details** button isn't shown
7. Try to access a class with the URL you just copied, you should not be able to

**Notes**
:potato: 