### PR TITLE
Remove buttons above confirmed steps

### DIFF
--- a/Frontend/app/problem/display/displayProblem.component.ts
+++ b/Frontend/app/problem/display/displayProblem.component.ts
@@ -149,8 +149,8 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
     }
   }
 
-  incorrectGoodStep() {
-    this.confirmedStepIndex = this.activeStepCount;
+  incorrectGoodStep(index) {
+    this.confirmedStepIndex = index;
     this.toastr.warning("Mentii did not make a mistake here", "Try Again");
   }
 

--- a/Frontend/app/problem/display/displayProblem.component.ts
+++ b/Frontend/app/problem/display/displayProblem.component.ts
@@ -50,7 +50,7 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
 
   /* variable to keep track of what step the last correction was so
     that previously confirmed steps do not have a mistake button */
-  lastCorrection = 0;
+  confirmedStepIndex = 0;
 
   constructor(public problemService: ProblemService, public toastr: ToastrService, public router: Router, private activatedRoute: ActivatedRoute){
   }
@@ -95,7 +95,7 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
       this.toastr.success("Your correction got Mentii back on the right path", "Good Job!");
       this.problemTree[this.activeStepCount]['badStepShown'] = false; // Close the bad step subtree
       this.stepIsBeingCorrected = false;
-      this.lastCorrection = this.activeStepCount;
+      this.confirmedStepIndex = this.activeStepCount;
       this.showNextStep(); // Progress to the next step, after the correction
     } else {
       this.toastr.error("This correction won't help Mentii get back on the right path", "Not Quite...");
@@ -150,6 +150,7 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
   }
 
   incorrectGoodStep() {
+    this.confirmedStepIndex = this.activeStepCount;
     this.toastr.warning("Mentii did not make a mistake here", "Try Again");
   }
 

--- a/Frontend/app/problem/display/displayProblem.component.ts
+++ b/Frontend/app/problem/display/displayProblem.component.ts
@@ -48,6 +48,10 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
   selectedStepLimit = 1;
   stepLimit = 0;
 
+  /* variable to keep track of what step the last correction was so
+    that previously confirmed steps do not have a mistake button */
+  lastCorrection = 0;
+
   constructor(public problemService: ProblemService, public toastr: ToastrService, public router: Router, private activatedRoute: ActivatedRoute){
   }
 
@@ -91,6 +95,7 @@ export class DisplayProblemComponent implements OnInit, OnDestroy {
       this.toastr.success("Your correction got Mentii back on the right path", "Good Job!");
       this.problemTree[this.activeStepCount]['badStepShown'] = false; // Close the bad step subtree
       this.stepIsBeingCorrected = false;
+      this.lastCorrection = this.activeStepCount;
       this.showNextStep(); // Progress to the next step, after the correction
     } else {
       this.toastr.error("This correction won't help Mentii get back on the right path", "Not Quite...");

--- a/Frontend/app/problem/display/displayProblem.html
+++ b/Frontend/app/problem/display/displayProblem.html
@@ -67,13 +67,13 @@
 
               <!-- Don't show this button if we are on the first good step, that's the
                    problem declaration. This will be shown on the active step -->
-              <button type="button" class="btn btn-danger btn-sm" (click)="incorrectGoodStep()"
+              <button type="button" class="btn btn-danger btn-sm" (click)="incorrectGoodStep(goodStepIndex)"
               *ngIf="goodStepIndex != 0 && goodStepIndex == activeStepCount">
                 <i class="fa fa-hand-paper-o fa-lg" aria-hidden="true"></i> Mistake here Mentii
               </button>
 
               <!-- Only show this button on the non active steps -->
-              <a type="button" class="lightBadStep btn btn-sm" (click)="incorrectGoodStep()"
+              <a type="button" class="lightBadStep btn btn-sm" (click)="incorrectGoodStep(goodStepIndex)"
               *ngIf="goodStepIndex != 0 && goodStepIndex > confirmedStepIndex && goodStepIndex != activeStepCount">
                 <i class="fa fa-hand-paper-o fa-lg" aria-hidden="true"></i> Mistake here Mentii
               </a>

--- a/Frontend/app/problem/display/displayProblem.html
+++ b/Frontend/app/problem/display/displayProblem.html
@@ -74,7 +74,7 @@
 
               <!-- Only show this button on the non active steps -->
               <a type="button" class="lightBadStep btn btn-sm" (click)="incorrectGoodStep()"
-              *ngIf="goodStepIndex != 0 && goodStepIndex != activeStepCount">
+              *ngIf="goodStepIndex != 0 && goodStepIndex > lastCorrection && goodStepIndex != activeStepCount">
                 <i class="fa fa-hand-paper-o fa-lg" aria-hidden="true"></i> Mistake here Mentii
               </a>
             </div>

--- a/Frontend/app/problem/display/displayProblem.html
+++ b/Frontend/app/problem/display/displayProblem.html
@@ -74,7 +74,7 @@
 
               <!-- Only show this button on the non active steps -->
               <a type="button" class="lightBadStep btn btn-sm" (click)="incorrectGoodStep()"
-              *ngIf="goodStepIndex != 0 && goodStepIndex > lastCorrection && goodStepIndex != activeStepCount">
+              *ngIf="goodStepIndex != 0 && goodStepIndex > confirmedStepIndex && goodStepIndex != activeStepCount">
                 <i class="fa fa-hand-paper-o fa-lg" aria-hidden="true"></i> Mistake here Mentii
               </a>
             </div>

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentii",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "mentii-frontend",
   "scripts": {
     "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",


### PR DESCRIPTION
Removes buttons above steps that have confirmed corrections by students

**Significant Changes**
1. Buttons do not show above steps where a "Correct Mentii" step has been successfully completed
2. Steps above where student clicks correction button and **Try Again, this is actually correct** are  hidden

**How to Test**
1. Make sure correction buttons do not show up before last correction

**Notes**
:ice_cream: 